### PR TITLE
Update versions due to 5.0.3 release.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,12 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'ome', name: 'formats-gpl', version: '5.0.2'){
+    compile(group: 'ome', name: 'formats-gpl', version: '5.0.3'){
     }
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){
         exclude group: 'org.testng', module: 'testng'
     }
-    compile(group: 'omero', name: 'blitz', version: '5.0.3-ice35-SNAPSHOT') {
+    compile(group: 'omero', name: 'blitz', version: '5.0.4-ice35-SNAPSHOT') {
         exclude group: 'ome', module: 'bio-formats'
         exclude group: 'org.springframework.ldap', module: 'spring-ldap'
         exclude group: 'org.testng', module: 'testng'

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.10</version>
     </parent>
 
     <groupId>com.example</groupId>
     <artifactId>MyClient</artifactId>
-    <version>5.0.9</version>
+    <version>5.0.10</version>
 
     <name>Example</name>
     <description>An example maven project for connection to OMERO</description>


### PR DESCRIPTION
To test this PR, check that executing `mvn` and `gradle` doesn't produce an error. Dependency listing with both build systems works fine, so I wouldn't expect any hiccups.
