### PR TITLE
Enable Travis for build validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+
+# This (sudo: false) is needed to "run on container-based infrastructure" on
+# which cache: is available
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+# http://docs.travis-ci.com/user/caching/#Arbitrary-directories
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ language: java
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-# http://docs.travis-ci.com/user/caching/#Arbitrary-directories
-cache:
-  directories:
-  - $HOME/.m2
+env:
+  - BUILD=gradle
+  - BUILD=maven
+
+before_install:
+  - if [[ $BUILD == 'maven' ]]; then rm build.gradle; fi

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
+        name 'OME'
+        url 'http://artifacts.openmicroscopy.org/artifactory/simple/ome.experimental/'
+    }
+    maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/maven/'
     }
 }
@@ -26,7 +30,6 @@ dependencies {
         exclude group: 'org.testng', module: 'testng'
     }
     compile(group: 'omero', name: 'blitz', version: '5.1.3-ice35-b52') {
-        exclude group: 'ome', module: 'bio-formats'
         exclude group: 'org.springframework.ldap', module: 'spring-ldap'
         exclude group: 'org.testng', module: 'testng'
         exclude group: 'hsqldb', module: 'hsqldb'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+    compile(group: 'edu.car', name: 'thredds-parent', version: '4.3.19')
     compile(group: 'ome', name: 'formats-gpl', version: '5.1.3'){
     }
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){

--- a/build.gradle
+++ b/build.gradle
@@ -14,16 +14,14 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        name 'OME'
-        url 'http://artifacts.openmicroscopy.org/artifactory/simple/ome.experimental/'
-    }
+        name 'Unidata'
+        url 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases'}
     maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/maven/'
     }
 }
 
 dependencies {
-    compile(group: 'edu.ucar', name: 'thredds-parent', version: '4.3.19')
     compile(group: 'ome', name: 'formats-gpl', version: '5.1.3'){
     }
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'edu.ecar', name: 'thredds-parent', version: '4.3.19')
+    compile(group: 'edu.ucar', name: 'thredds-parent', version: '4.3.19')
     compile(group: 'ome', name: 'formats-gpl', version: '5.1.3'){
     }
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ def javaOpts = [
     '-Xmx512M'
 ]
 
-version '5.1.11'
+version '5.1.12'
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ def javaOpts = [
 version '5.1.11'
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/maven/'
@@ -18,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'edu.car', name: 'thredds-parent', version: '4.3.19')
+    compile(group: 'edu.ecar', name: 'thredds-parent', version: '4.3.19')
     compile(group: 'ome', name: 'formats-gpl', version: '5.1.3'){
     }
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.1.11</version>
+        <version>5.1.12</version>
     </parent>
 
     <groupId>com.example</groupId>
     <artifactId>MyClient</artifactId>
-    <version>5.1.11</version>
+    <version>5.1.12</version>
 
     <name>Example</name>
     <description>An example maven project for connection to OMERO</description>


### PR DESCRIPTION
This PR:

- enables the Travis build for validating the minimal client build
- removes the deprecated `bio-format` modules
- uses the Unidata Maven repository for retrieving netcdf and its parent