### PR TITLE
Pom omero client 5.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,6 @@ repositories {
     maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/maven/'
     }
-    maven {
-        url 'http://artifacts.openmicroscopy.org/artifactory/simple/ome.staging/'
-    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'ome', name: 'formats-gpl', version: '5.1.6'){
+    compile(group: 'ome', name: 'formats-gpl', version: '5.1.7'){
     }
-    compile(group: 'ome', name: 'formats-bsd', version: '5.1.6'){
+    compile(group: 'ome', name: 'formats-bsd', version: '5.1.7'){
     }
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){
         exclude group: 'org.testng', module: 'testng'
     }
-    compile(group: 'omero', name: 'blitz', version: '5.2.1-ice35-SNAPSHOT') {
+    compile(group: 'omero', name: 'blitz', version: '5.2.1-ice35-b15') {
         exclude group: 'org.springframework.ldap', module: 'spring-ldap'
         exclude group: 'org.testng', module: 'testng'
         exclude group: 'hsqldb', module: 'hsqldb'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ def javaOpts = [
     '-Xmx512M'
 ]
 
-version '5.2.1-SNAPSHOT'
+version '5.2.1'
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'ome', name: 'formats-gpl', version: '5.1.7-SNAPSHOT'){
+    compile(group: 'ome', name: 'formats-gpl', version: '5.1.6'){
     }
-    compile(group: 'ome', name: 'formats-bsd', version: '5.1.7-SNAPSHOT'){
+    compile(group: 'ome', name: 'formats-bsd', version: '5.1.6'){
     }
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){
         exclude group: 'org.testng', module: 'testng'
@@ -34,7 +34,6 @@ dependencies {
         exclude group: 'org.testng', module: 'testng'
         exclude group: 'hsqldb', module: 'hsqldb'
     }
-    compile(group: 'com.google.guava', name: 'guava', version: '17.0')
 }
 
 startScripts {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ repositories {
     maven {
         url 'http://artifacts.openmicroscopy.org/artifactory/maven/'
     }
+    maven {
+        url 'http://artifacts.openmicroscopy.org/artifactory/simple/ome.staging/'
+    }
 }
 
 dependencies {

--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,6 @@
           <id>ome.maven</id>
           <url>http://artifacts.openmicroscopy.org/artifactory/maven/</url>
         </repository>
-        <repository>
-          <id>ome.staging</id>
-          <url>http://artifacts.openmicroscopy.org/artifactory/simple/ome.staging/</url>
-        </repository>
     </repositories>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
           <id>ome.maven</id>
           <url>http://artifacts.openmicroscopy.org/artifactory/maven/</url>
         </repository>
+        <repository>
+          <id>ome.staging</id>
+          <url>http://artifacts.openmicroscopy.org/artifactory/simple/ome.staging//</url>
+        </repository>
     </repositories>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,6 @@
           <groupId>ome</groupId>
           <artifactId>formats-gpl</artifactId>
         </dependency>
-        <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>17.0</version>
-        </dependency>
     </dependencies>
     <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         </repository>
         <repository>
           <id>ome.staging</id>
-          <url>http://artifacts.openmicroscopy.org/artifactory/simple/ome.staging//</url>
+          <url>http://artifacts.openmicroscopy.org/artifactory/simple/ome.staging/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.2.1-SNAPSHOT</version>
+        <version>5.2.1</version>
     </parent>
 
     <groupId>com.example</groupId>
@@ -28,12 +28,10 @@
         <dependency>
           <groupId>ome</groupId>
           <artifactId>formats-bsd</artifactId>
-          <version>5.1.7-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>ome</groupId>
           <artifactId>formats-gpl</artifactId>
-          <version>5.1.7-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.4</version>
     </parent>
 
     <groupId>com.example</groupId>
     <artifactId>MyClient</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.2.1</version>
 
     <name>Example</name>
     <description>An example maven project for connection to OMERO using the Java gateway.</description>
@@ -23,7 +23,6 @@
         <dependency>
           <groupId>omero</groupId>
           <artifactId>blitz</artifactId>
-          <version>5.2.1-${ice.version}-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>ome</groupId>


### PR DESCRIPTION
Follow-up of https://github.com/ome/pom-omero-client/pull/7, this PR consumes the 5.2.1 `pom-omero-client` and inherits the `formats-bsd/formats-gpl` version numbers.