### PR TITLE
Bump minimal-omero-client to use OMERO 5.2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ def javaOpts = [
     '-Xmx512M'
 ]
 
-version '5.2.3'
+version '5.2.5'
 
 repositories {
     mavenLocal()
@@ -29,7 +29,7 @@ dependencies {
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){
         exclude group: 'org.testng', module: 'testng'
     }
-    compile(group: 'omero', name: 'blitz', version: '5.2.3-ice35-b22') {
+    compile(group: 'omero', name: 'blitz', version: '5.2.5-ice35-b28') {
         exclude group: 'org.springframework.ldap', module: 'spring-ldap'
         exclude group: 'org.testng', module: 'testng'
         exclude group: 'hsqldb', module: 'hsqldb'

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.2.9</version>
+        <version>5.2.10</version>
     </parent>
 
     <groupId>com.example</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.2.7</version>
+        <version>5.2.9</version>
     </parent>
 
     <groupId>com.example</groupId>
     <artifactId>MyClient</artifactId>
-    <version>5.2.3</version>
+    <version>5.2.5</version>
 
     <name>Example</name>
     <description>An example maven project for connection to OMERO using the Java gateway.</description>

--- a/src/main/java/com/example/SimpleConnection.java
+++ b/src/main/java/com/example/SimpleConnection.java
@@ -96,7 +96,6 @@ public class SimpleConnection {
             //Do something e.g. loading user's data.
             //Load the projects/datasets owned by the user currently logged in.
             client.loadProjects();
-            Thread.sleep(4000);
         } catch (Exception e) {
             System.out.println(e);
         } finally {

--- a/src/main/java/com/example/SimpleConnection.java
+++ b/src/main/java/com/example/SimpleConnection.java
@@ -96,6 +96,7 @@ public class SimpleConnection {
             //Do something e.g. loading user's data.
             //Load the projects/datasets owned by the user currently logged in.
             client.loadProjects();
+            Thread.sleep(4000);
         } catch (Exception e) {
         } finally {
             client.disconnect();

--- a/src/main/java/com/example/SimpleConnection.java
+++ b/src/main/java/com/example/SimpleConnection.java
@@ -98,6 +98,7 @@ public class SimpleConnection {
             client.loadProjects();
             Thread.sleep(4000);
         } catch (Exception e) {
+            System.out.println(e);
         } finally {
             client.disconnect();
         }


### PR DESCRIPTION
This follows the OMERO 5.2.5 release and the bump of the pom-omero-client. As we did not bump with the 5.2.4 release, the version numbers are jumping from 5.2.3 to 5.2.5 but we can use 5.2.4 if preferrable.