### PR TITLE
Add omero-test-infra to Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.settings/
 /target/
 .*un~
+.omero

--- a/.omeroci/test-data
+++ b/.omeroci/test-data
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Set up the data structure needed for the tests
+
+set -e
+set -u
+set -x
+
+OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
+WORKDIR=$(mktemp -d)
+
+function cleanup {
+  rm -rf "$WORKDIR"
+  echo "Deleted temp working directory $WORKDIR"
+}
+
+trap cleanup EXIT
+
+export PATH=$PATH:${OMERO_DIST}/bin
+omero login root@localhost -w omero
+omero group add testGroup
+omero user add testUser Test User testGroup -P omero
+omero login testUser@localhost -w omero
+
+# create a simple project/dataset/image hierarchy
+DATASET=$(omero obj new Dataset name=TestDataset)
+PROJECT=$(omero obj new Project name=TestProject)
+omero obj new ProjectDatasetLink parent=$PROJECT child=$DATASET
+touch "$WORKDIR/8bit-unsigned&pixelType=uint8&sizeZ=3&sizeC=5&sizeT=7&sizeX=512&sizeY=512.fake"
+IMAGE=$(omero import --output=ids  "$WORKDIR/8bit-unsigned&pixelType=uint8&sizeZ=3&sizeC=5&sizeT=7&sizeX=512&sizeY=512.fake" -T Dataset:id:1)
+
+# Copied from rOMERO-gateway/.omeroci/test-data
+# Should this be the default value?

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ sudo: required
 before_install:
   - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
 
-before_install:
+script:
   - .omero/lib-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: java
 
-# This (sudo: false) is needed to "run on container-based infrastructure" on
-# which cache: is available
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
-
-env:
-  - BUILD=gradle
-  - BUILD=maven
+sudo: required
 
 before_install:
-  - if [[ $BUILD == 'maven' ]]; then rm build.gradle; fi
+  - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
+
+before_install:
+  - .omero/lib-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:8
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+ENV GRADLE_VERSION 3.5.1
+RUN wget -q https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+    && unzip gradle-${GRADLE_VERSION}-bin.zip -d /opt \
+    && rm gradle-${GRADLE_VERSION}-bin.zip
+
+COPY . /src
+
+WORKDIR /src
+RUN /opt/gradle-${GRADLE_VERSION}/bin/gradle build install
+
+ENV ICE_CONFIG /src/ice.config
+WORKDIR /src/build/install/src
+CMD ["./bin/src"]

--- a/ice.config
+++ b/ice.config
@@ -1,4 +1,4 @@
 omero.host=omero
 omero.port=4064
-omero.user=root
+omero.user=testUser
 omero.pass=omero

--- a/ice.config
+++ b/ice.config
@@ -1,0 +1,4 @@
+omero.host=localhost
+omero.port=4064
+omero.user=root
+omero.pass=omero

--- a/ice.config
+++ b/ice.config
@@ -1,4 +1,4 @@
-omero.host=localhost
+omero.host=omero
 omero.port=4064
 omero.user=root
 omero.pass=omero

--- a/src/main/java/com/example/SimpleConnection.java
+++ b/src/main/java/com/example/SimpleConnection.java
@@ -88,10 +88,10 @@ public class SimpleConnection {
         Collection<ProjectData> projects = browse.getProjects(ctx);
     }
 
+    /** Loads the image with the id 1.*/
     private void loadFirstImage()
         throws Exception
     {
-
         ParametersI params = new ParametersI();
         params.acquisitionData();
         BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
@@ -114,8 +114,8 @@ public class SimpleConnection {
         SimpleConnection client = new SimpleConnection();
         try {
             client.connect(args);
-            //Do something e.g. loading user's data.
-            //Load the projects/datasets owned by the user currently logged in.
+            // Do something e.g. loading user's data.
+            // Load the projects/datasets owned by the user currently logged in.
             client.loadProjects();
             client.loadFirstImage();
         } finally {

--- a/src/main/java/com/example/SimpleConnection.java
+++ b/src/main/java/com/example/SimpleConnection.java
@@ -9,13 +9,19 @@ package com.example;
 
 import java.util.Collection;
 
+import omero.api.ThumbnailStorePrx;
+import omero.sys.ParametersI;
+
 import omero.gateway.Gateway;
 import omero.gateway.LoginCredentials;
 import omero.gateway.SecurityContext;
 import omero.gateway.facility.BrowseFacility;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.ProjectData;
+import omero.gateway.model.ImageData;
+import omero.gateway.model.PixelsData;
 import omero.log.SimpleLogger;
+
 
 /**
  * A simple connection to an OMERO server using the Java gateway
@@ -82,6 +88,20 @@ public class SimpleConnection {
         Collection<ProjectData> projects = browse.getProjects(ctx);
     }
 
+    private void loadFirstImage()
+        throws Exception
+    {
+
+        ParametersI params = new ParametersI();
+        params.acquisitionData();
+        BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
+        ImageData image = browse.getImage(ctx, 1L, params);
+        PixelsData pixels = image.getDefaultPixels();
+        ThumbnailStorePrx store = gateway.getThumbnailService(ctx);
+        store.setPixelsId(pixels.getId());
+        System.out.println("Ready to get thumbnail");
+    }
+
     /** Creates a new instance.*/
     SimpleConnection()
     {
@@ -97,8 +117,7 @@ public class SimpleConnection {
             //Do something e.g. loading user's data.
             //Load the projects/datasets owned by the user currently logged in.
             client.loadProjects();
-        } catch (Exception e) {
-            System.out.println(e);
+            client.loadFirstImage();
         } finally {
             client.disconnect();
         }

--- a/src/main/java/com/example/SimpleConnection.java
+++ b/src/main/java/com/example/SimpleConnection.java
@@ -64,6 +64,7 @@ public class SimpleConnection {
     {
         LoginCredentials cred = new LoginCredentials(args);
         ExperimenterData user = gateway.connect(cred);
+        System.out.println("Connected as " + user.getUserName());
         ctx = new SecurityContext(user.getGroupId());
     }
     


### PR DESCRIPTION
See https://github.com/openmicroscopy/omero-test-infra/issues/1 and related downstream PRs

This PR adds the `omero-test-infra` framework to `minimal-omero-client` very similarly to what was done in https://github.com/ome/rOMERO-gateway/pull/22, using `.omero/lib-docker` as the entrypoint for tests. A minimal `Dockerfile` builds the client using `gradle` and sets the binary as the `RUN` command.

Open for review and feedback at this stage, there might be various improvements we want to consider before merging.

In terms of infrastructure impact, I would expect this should suffice to drop [OMERO-DEV-merge-maven-client](https://ci.openmicroscopy.org/job/OMERO-DEV-merge-maven-client/).
 