### PR TITLE
Bump OMERO versions to 5.4.10

### DIFF
--- a/.omeroci/test-data
+++ b/.omeroci/test-data
@@ -27,7 +27,7 @@ DATASET=$(omero obj new Dataset name=TestDataset)
 PROJECT=$(omero obj new Project name=TestProject)
 omero obj new ProjectDatasetLink parent=$PROJECT child=$DATASET
 touch "$WORKDIR/8bit-unsigned&pixelType=uint8&sizeZ=3&sizeC=5&sizeT=7&sizeX=512&sizeY=512.fake"
-IMAGE=$(omero import --output=ids  "$WORKDIR/8bit-unsigned&pixelType=uint8&sizeZ=3&sizeC=5&sizeT=7&sizeX=512&sizeY=512.fake" -T Dataset:id:1)
+IMAGE=$(omero import --skip=upgrade --output=ids  "$WORKDIR/8bit-unsigned&pixelType=uint8&sizeZ=3&sizeC=5&sizeT=7&sizeX=512&sizeY=512.fake" -T Dataset:id:1)
 
 # Copied from rOMERO-gateway/.omeroci/test-data
 # Should this be the default value?

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ def javaOpts = [
     '-Xmx512M'
 ]
 
-version '5.4.9'
+version '5.4.10'
 
 repositories {
     mavenLocal()
@@ -29,7 +29,7 @@ dependencies {
     compile(group: 'org.springframework.ldap', name: 'spring-ldap', version: '1.3.0.RELEASE', classifier: 'all'){
         exclude group: 'org.testng', module: 'testng'
     }
-    compile(group: 'omero', name: 'blitz', version: '5.4.9-ice36-b101') {
+    compile(group: 'omero', name: 'blitz', version: '5.4.10-ice36-b105') {
         exclude group: 'org.springframework.ldap', module: 'spring-ldap'
         exclude group: 'org.testng', module: 'testng'
         exclude group: 'hsqldb', module: 'hsqldb'

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
           <groupId>omero</groupId>
           <artifactId>blitz</artifactId>
-          <version>5.4.10-${ice.version}-b105</omero.version>
+          <version>5.4.10-${ice.version}-b105</version>
         </dependency>
         <dependency>
           <groupId>ome</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.4.9</version>
+        <version>5.4.10</version>
     </parent>
 
     <groupId>com.example</groupId>
     <artifactId>MyClient</artifactId>
-    <version>5.4.9</version>
+    <version>5.4.10</version>
 
     <name>Example</name>
     <description>An example maven project for connection to OMERO using the Java gateway.</description>
@@ -23,6 +23,7 @@
         <dependency>
           <groupId>omero</groupId>
           <artifactId>blitz</artifactId>
+          <version>5.4.10-${ice.version}-b105</omero.version>
         </dependency>
         <dependency>
           <groupId>ome</groupId>


### PR DESCRIPTION
Similarly to https://github.com/openmicroscopy/ansible-role-omero-server/pull/34, the Java security changes disabling anonymous ciphers have made their way to the `openjdk` library causing Travis to fail with `SSLHandshakeException` - see https://travis-ci.org/ome/omero-plugins/jobs/515276033.

This PR bumps the OMERO version to 5.4.10 which should be sufficient to fix the tests and pass Travis.
