### PR TITLE
Replace mysterious args Eval.me("['-f', '.']") with environment ICE_CONFIG

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,5 +47,5 @@ startScripts {
 }
 
 run {
-    args Eval.me("['-f', '.']")
+    environment "ICE_CONFIG", "ice.config"
 }


### PR DESCRIPTION
No-one seems to know what setting the gradle `run` args to `-f .` does. Set `ICE_CONFIG=ice.config` instead.

- https://openmicroscopy.slack.com/archives/C0K5EED3R/p1555075852050100