### PR TITLE
Repositories cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 
 before_install:
   - git clone --recurse-submodules git://github.com/ome/omero-test-infra .omero
+  - mvn install
 
 script:
   - .omero/lib-docker

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,6 @@
           <name>unidata-releases</name>
           <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
         </repository>
-        <repository>
-          <id>zeroc</id>
-          <name>zeroc</name>
-          <url>https://repo.zeroc.com/nexus/content/repositories/releases/</url>
-        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
Remove unnecessary ZeroC repository in the `pom.xml` (this was necessary for Ice 3.5 which has been dropped in OMERO 5.5.)

Also adds `mvn install` in `.travis.yml` to ensure this path is minimally tested.