### PR TITLE
Bump dependencies to current Java gateway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.openmicroscopy:omero-gateway:5.6.4")
+    implementation("org.openmicroscopy:omero-gateway:5.6.5")
 }
 
 startScripts {

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        name 'Unidata'
-        url 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases'}
-    maven {
         url 'https://artifacts.openmicroscopy.org/artifactory/maven/'
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
           <groupId>org.openmicroscopy</groupId>
           <artifactId>omero-gateway</artifactId>
-          <version>5.6.3</version>
+          <version>5.6.5</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,6 @@
           <id>ome.maven</id>
           <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
         </repository>
-        <repository>
-          <id>unidata-releases</id>
-          <name>unidata-releases</name>
-          <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
-        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
Also removes usage of the Unidata repository.